### PR TITLE
Change field type for `sender` to Small Text to allow longer addresses

### DIFF
--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/single_email_ct/single_email_ct.json
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/single_email_ct/single_email_ct.json
@@ -108,7 +108,7 @@
   },
   {
    "fieldname": "sender",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "From",
    "read_only": 1
   },
@@ -195,7 +195,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-13 12:15:53.005599",
+ "modified": "2025-02-24 13:25:15.253712",
  "modified_by": "Administrator",
  "module": "Frappe Gmail Thread",
  "name": "Single Email CT",


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

- Updates the field type for `sender` to Small Text instead of Data to allow email addresses longer than 140.

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->

cc @KanchanChauhan 