### PR TITLE
Fix: Random name for long attachments and add owner to involved_users and add unlink button

### DIFF
--- a/frappe_gmail_thread/api/activity.py
+++ b/frappe_gmail_thread/api/activity.py
@@ -78,3 +78,12 @@ def relink_gmail_thread(name, doctype, docname):
     thread.reference_name = docname
     thread.save()
     return thread.reference_name
+
+
+@frappe.whitelist()
+def unlink_gmail_thread(name):
+    thread = frappe.get_doc("Gmail Thread", name)
+    thread.reference_doctype = None
+    thread.reference_name = None
+    thread.save()
+    return thread.reference_name

--- a/frappe_gmail_thread/api/pubsub.py
+++ b/frappe_gmail_thread/api/pubsub.py
@@ -29,5 +29,4 @@ def callback():
                 user=user.name,
                 history_id=history_id,
             )
-        print("PubSub message received: ", message)
     return "OK"

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.js
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.js
@@ -41,6 +41,21 @@ frappe.ui.form.on("Gmail Thread", {
       );
     });
     if (frm.doc.reference_doctype && frm.doc.reference_name) {
+      frm.add_custom_button(__("Unlink"), function () {
+        frappe.confirm(__("Are you sure you want to unlink this Gmail Thread?"), function () {
+          frappe.call({
+            method: "frappe_gmail_thread.api.activity.unlink_gmail_thread",
+            args: {
+              name: frm.doc.name,
+            },
+            callback: function (r) {
+              if (r.message) {
+                frm.reload_doc();
+              }
+            },
+          });
+        });
+      });
       frm.add_custom_button(__("Open Linked Document"), function () {
         frappe.set_route("Form", frm.doc.reference_doctype, frm.doc.reference_name);
       });

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/single_email_ct/single_email_ct.json
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/single_email_ct/single_email_ct.json
@@ -195,7 +195,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-24 13:25:15.253712",
+ "modified": "2025-02-24 18:53:56.797831",
  "modified_by": "Administrator",
  "module": "Frappe Gmail Thread",
  "name": "Single Email CT",

--- a/frappe_gmail_thread/patches/v0_1/reset_sync_history.py
+++ b/frappe_gmail_thread/patches/v0_1/reset_sync_history.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+    reset_all_history_id()
+
+
+def reset_all_history_id():
+    gmail_accounts = frappe.get_all(
+        "Gmail Account",
+        filters={"gmail_enabled": 1},
+        fields=["name"],
+    )
+    for gmail_account in gmail_accounts:
+        gaccount = frappe.get_doc("Gmail Account", gmail_account.name)
+        gaccount.last_historyid = None
+        gaccount.save()
+        frappe.db.commit()


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

- If filename in attachment is more than 140 characters, use uuid4 to create a random filename instead so that it can fit in the Data field.
- Add the user from whose account an email if being synced to involved_user, even if he isn't a part of sender or receiver emails. This can happen if the email is sent to a group.
- Adds a patch that can be run manually to reset history id, to allow resyncing. This can be run via `bench run-patch frappe_gmail_thread.patches.v0_1.reset_sync_history`
- Adds an Unlink button in Gmail Thread if it is already linked.

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->