### PR TITLE
Refactor: Reset history id on labels change

### DIFF
--- a/frappe_gmail_thread/api/pubsub.py
+++ b/frappe_gmail_thread/api/pubsub.py
@@ -37,7 +37,6 @@ def callback():
                 frappe.enqueue(
                     "frappe_gmail_thread.frappe_gmail_thread.doctype.gmail_thread.gmail_thread.sync",
                     user=user.name,
-                    history_id=history_id,
                     queue="long",
                     job_name=job_name,
                     job_id=job_name,

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.js
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.js
@@ -44,6 +44,25 @@ frappe.ui.form.on("Gmail Account", {
       frm.add_custom_button(__("Fetch Labels"), function () {
         frm.events.fetch_labels(frm);
       });
+      frm.add_custom_button(__("Resync Emails"), function () {
+        frappe.confirm(__("Are you sure you want to resync all emails?"), function () {
+          frappe.call({
+            method: "frappe_gmail_thread.frappe_gmail_thread.doctype.gmail_account.gmail_account.sync_labels_api",
+            type: "POST",
+            args: {
+              args: {
+                doc_name: frm.doc.name,
+                reset_historyid: true,
+              },
+            },
+            callback: function (r) {},
+            error: function (r) {
+              frappe.msgprint(__("Something went wrong. Please try again later, or report issue in GitHub issues."));
+              frm.reload_doc();
+            },
+          });
+        });
+      });
     }
     frm.fields_dict.labels.$wrapper.find(".grid-row-check").hide();
   },

--- a/frappe_gmail_thread/tasks/sync.py
+++ b/frappe_gmail_thread/tasks/sync.py
@@ -12,13 +12,11 @@ def sync_emails():
         gaccount = frappe.get_doc("Gmail Account", gmail_account.name)
         if gaccount.refresh_token:
             user = gaccount.linked_user
-            history_id = gaccount.last_historyid
             job_name = f"gmail_thread_sync_{user}"
             if not is_job_enqueued(job_name):
                 frappe.enqueue(
                     "frappe_gmail_thread.frappe_gmail_thread.doctype.gmail_thread.gmail_thread.sync",
                     user=user,
-                    history_id=history_id,
                     queue="long",
                     job_name=job_name,
                     job_id=job_name,


### PR DESCRIPTION


> Please provide enough information so that others can review your pull request:

- When a user changes labels to be synced, reset his history_id, so all emails gets synced.
- Also, add a button to resync all emails (by resetting historyid)
- Minor tweaks to improve error handling and syncing:
    - Don't use history_id provided by webhook, instead use last stored history_id so emails don't get missed.
    - Save new history_id at the end of whole sync, to ensure that in case of error, no email get missed.

> Explain the **details** for making this change. What existing problem does the pull request solve?


> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->