### PR TITLE
Set creation date for gmail thread based on email delivery time

### DIFF
--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.py
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.py
@@ -64,9 +64,7 @@ class GmailAccount(Document):
             return True
         return super().has_value_changed(fieldname)
 
-    def on_update(self):
-        if self.linked_user != frappe.session.user:
-            return
+    def before_save(self):
         if self.has_value_changed("gmail_enabled") and self.gmail_enabled:
             google_settings = frappe.get_single("Google Settings")
             if not google_settings.enable:
@@ -100,7 +98,6 @@ class GmailAccount(Document):
                     )
         if self.has_value_changed("labels"):
             self.last_historyid = 0  # reset history id if labels are changed
-            self.save()
 
             if self.gmail_enabled and self.refresh_token:
                 has_labels = False

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
@@ -42,7 +42,7 @@ class GmailThread(Document):
             return True
         return super().has_value_changed(fieldname)
 
-    def on_update(self):
+    def before_save(self):
         if self.has_value_changed("involved_users"):
             # give permission of all files to all involved users
             attachments = frappe.get_all(
@@ -69,7 +69,6 @@ class GmailThread(Document):
             if self.reference_doctype and self.reference_name:
                 if self.status == "Open":
                     self.status = "Linked"
-                    self.save(ignore_permissions=True)
                 # check if there is any other thread with same reference doctype and name
                 threads = frappe.get_all(
                     "Gmail Thread",
@@ -89,7 +88,6 @@ class GmailThread(Document):
                         break
             elif self.status == "Linked":
                 self.status = "Open"
-                self.save(ignore_permissions=True)
 
 
 @frappe.whitelist(methods=["POST"])

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
@@ -167,6 +167,7 @@ def sync(user=None):
                         continue
                     if "DRAFT" in raw_email.get("labelIds", []):
                         continue
+                    is_new_thread = False
                     try:
                         email, email_object = create_new_email(raw_email, gmail_account)
                     except AlreadyExistsError:
@@ -190,6 +191,7 @@ def sync(user=None):
                         gmail_thread = frappe.new_doc("Gmail Thread")
                         gmail_thread.gmail_thread_id = thread_id
                         gmail_thread.gmail_account = gmail_account.name
+                        is_new_thread = True
                     if not gmail_thread.subject_of_first_mail:
                         gmail_thread.subject_of_first_mail = email.subject
                         gmail_thread.creation = email.date_and_time
@@ -214,6 +216,14 @@ def sync(user=None):
                         email.date_and_time,
                         update_modified=False,
                     )
+                    if is_new_thread:  # update creation date
+                        frappe.db.set_value(
+                            "Gmail Thread",
+                            gmail_thread.name,
+                            "creation",
+                            email.date_and_time,
+                            update_modified=False,
+                        )
                     # set owner to linked user
                     frappe.db.set_value(
                         "Gmail Thread",
@@ -266,6 +276,7 @@ def sync(user=None):
                         thread_id = message["threadId"]
                         gmail_thread = find_gmail_thread(thread_id)
                         involved_users = set()
+                        is_new_thread = False
                         try:
                             email, email_object = create_new_email(
                                 raw_email, gmail_account
@@ -289,6 +300,7 @@ def sync(user=None):
                             gmail_thread = frappe.new_doc("Gmail Thread")
                             gmail_thread.gmail_thread_id = thread_id
                             gmail_thread.gmail_account = gmail_account.name
+                            is_new_thread = True
                         if not gmail_thread.subject_of_first_mail:
                             gmail_thread.subject_of_first_mail = email.subject
                             gmail_thread.creation = email.date_and_time
@@ -312,6 +324,14 @@ def sync(user=None):
                             email.date_and_time,
                             update_modified=False,
                         )
+                        if is_new_thread:  # update creation date
+                            frappe.db.set_value(
+                                "Gmail Thread",
+                                gmail_thread.name,
+                                "creation",
+                                email.date_and_time,
+                                update_modified=False,
+                            )
                         # if gmail thread has a reference doctype and name, then publish real-time activity
                         if (
                             gmail_thread.reference_doctype


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

- Currently, Gmail Thread have creation date as current date time
- This PR ensures that the creation date for the document is the actual email delivery time, not the time it synced.
- Also, this PR Changes the `on_update` controller hook to `before_save` for `GmailAccount` and `GmailThread`.

- Ref: https://github.com/rtCamp/erp-rtcamp/issues/2139

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->