### PR TITLE
Set creation date for gmail thread based on email delivery time

### DIFF
--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.py
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.py
@@ -64,9 +64,7 @@ class GmailAccount(Document):
             return True
         return super().has_value_changed(fieldname)
 
-    def on_update(self):
-        if self.linked_user != frappe.session.user:
-            return
+    def before_save(self):
         if self.has_value_changed("gmail_enabled") and self.gmail_enabled:
             google_settings = frappe.get_single("Google Settings")
             if not google_settings.enable:
@@ -100,7 +98,6 @@ class GmailAccount(Document):
                     )
         if self.has_value_changed("labels"):
             self.last_historyid = 0  # reset history id if labels are changed
-            self.save()
 
             if self.gmail_enabled and self.refresh_token:
                 has_labels = False


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

- Currently, Gmail Thread have creation date as current date time
- This PR ensures that the creation date for the document is the actual email delivery time, not the time it synced.
- Also, this PR Changes the `on_update` controller hook to `before_save` for `GmailAccount` and `GmailThread`.

- Ref: https://github.com/rtCamp/erp-rtcamp/issues/2139
- Ref: https://github.com/rtCamp/frappe-gmail-thread/pull/18

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> QA List

<!-- Add the QA list that needs to be done after PR merge -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behavior -->