### PR TITLE
refactor: Allow System Manager to update Gmail Account for all users

### DIFF
--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.json
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_account/gmail_account.json
@@ -56,8 +56,8 @@
   {
    "fieldname": "last_historyid",
    "fieldtype": "Int",
-   "hidden": 1,
-   "label": "Synced Upto (History ID)"
+   "label": "Synced Upto (History ID)",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.gmail_enabled == true;",
@@ -86,9 +86,10 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-24 20:19:33.736252",
+ "modified": "2025-07-21 19:07:34.020047",
  "modified_by": "Administrator",
  "module": "Frappe Gmail Thread",
  "name": "Gmail Account",
@@ -108,8 +109,22 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Description

- This PR allows System Manager to access all Gmail Accounts with edit permissions.
- This PR makes the field `Synced Upto (History ID)` read only, instead of hidden.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #