### PR TITLE
Update author email

### DIFF
--- a/frappe_gmail_thread/hooks.py
+++ b/frappe_gmail_thread/hooks.py
@@ -2,7 +2,7 @@ app_name = "frappe_gmail_thread"
 app_title = "Frappe Gmail Thread"
 app_publisher = "rtCamp"
 app_description = "This app is used to display emails as threads, just like Gmail does."
-app_email = "sys@rtcamp.com"
+app_email = "frappe@rtcamp.com"
 app_license = "agpl-3.0"
 
 # Apps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frappe_gmail_thread"
 authors = [
-    { name = "rtCamp", email = "sys@rtcamp.com"}
+    { name = "rtCamp", email = "frappe@rtcamp.com"}
 ]
 description = "This app is used to display emails as threads, just like Gmail does."
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request updates author and contact information across several project files to use the new email address, frappe@rtcamp.com, instead of the previous sys@rtcamp.com.