### PR TITLE
Enhance attachment handling by retrieving latest file URLs in get_attachments_data function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: 'node_modules|.git'
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 repos:

--- a/frappe_gmail_thread/utils/helpers.py
+++ b/frappe_gmail_thread/utils/helpers.py
@@ -205,7 +205,6 @@ def process_attachments(new_email, gmail_thread, email_object):
                 {
                     "file_name": _file.file_name,
                     "file_doc_name": _file.name,
-                    "file_url": _file.file_url,
                     "is_private": _file.is_private,
                 }
             )


### PR DESCRIPTION
## Description

* Added a new helper function `get_attachments_data` in `frappe_gmail_thread/api/activity.py` that loads the `attachments_data` from an email, then fetches the latest `file_url` for each attachment from the `File` doctype in the database. This ensures the returned attachment data always contains the current file URL.
* Updated the `get_linked_gmail_threads` function in `frappe_gmail_thread/api/activity.py` to use the new `get_attachments_data` function instead of directly loading the stored attachment data, ensuring consistency and up-to-date file URLs in API responses.
* Modified the `process_attachments` function in `frappe_gmail_thread/utils/helpers.py` to stop storing the `file_url` in the `attachments_data` structure, further enforcing that file URLs are always retrieved dynamically.

* This should fix the issue with S3 file URLs not being used in email attachments. 

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #