### PR TITLE
ci: Update runner type for workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   Bench-Build-Test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: docker.io/frappe/bench:latest
       options: --user root

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,9 @@ name: Bench Build Test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   pre-commit:
     name: "Frappe Linter"
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: alpine:latest # latest used here for simplicity, not recommended
     defaults:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the `ubuntu-latest` runner instead of `self-hosted` for both build/test and linter jobs. This change will improve consistency and reliability by using GitHub-hosted runners.

Workflow runner updates:

* [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L12-R12): Changed the `runs-on` parameter for the `Bench-Build-Test` job from `self-hosted` to `ubuntu-latest`.
* [`.github/workflows/linters.yml`](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acL16-R16): Changed the `runs-on` parameter for the `pre-commit` linter job from `self-hosted` to `ubuntu-latest`.