### PR TITLE
feat: Add `all_subjects` field to Gmail Thread

### DIFF
--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.json
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.json
@@ -17,7 +17,8 @@
   "column_break_cmhm",
   "gmail_account",
   "subject_of_first_mail",
-  "involved_users"
+  "involved_users",
+  "all_subjects"
  ],
  "fields": [
   {
@@ -95,6 +96,14 @@
    "label": "Status",
    "options": "Open\nClosed\nLinked",
    "reqd": 1
+  },
+  {
+   "fieldname": "all_subjects",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "All Subjects",
+   "read_only": 1,
+   "in_standard_filter": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
+++ b/frappe_gmail_thread/frappe_gmail_thread/doctype/gmail_thread/gmail_thread.py
@@ -89,6 +89,14 @@ class GmailThread(Document):
             elif self.status == "Linked":
                 self.status = "Open"
 
+        subjects = set()
+        if self.subject_of_first_mail:
+            subjects.add(self.subject_of_first_mail.strip())
+        for email in self.emails or []:
+            if email.subject:
+                subjects.add(email.subject.strip())
+        self.all_subjects = "\n".join(sorted(subjects))
+
 
 @frappe.whitelist(methods=["POST"])
 def sync_labels(account_name: str | Document, should_save: bool = True):

--- a/frappe_gmail_thread/patches/v0_1/backfill_all_subjects.py
+++ b/frappe_gmail_thread/patches/v0_1/backfill_all_subjects.py
@@ -1,0 +1,57 @@
+"""
+Backfill the `all_subjects` field for all existing Gmail Thread records.
+
+For each thread, collect:
+  - subject_of_first_mail  (parent field)
+  - subject                (from every child Single Email CT row)
+
+Store them newline-separated in all_subjects so the list-view subject
+filter can search across all subjects in a thread.
+"""
+
+import frappe
+
+
+def execute():
+    GmailThread = frappe.qb.DocType("Gmail Thread")
+    SingleEmailCT = frappe.qb.DocType("Single Email CT")
+
+    # Single query: all threads with their parent subject
+    threads = (
+        frappe.qb.from_(GmailThread)
+        .select(GmailThread.name, GmailThread.subject_of_first_mail)
+        .run(as_dict=True)
+    )
+    subject_map = {}
+    for t in threads:
+        subjects = subject_map.setdefault(t.name, set())
+        if t.subject_of_first_mail:
+            subjects.add(t.subject_of_first_mail.strip())
+
+    # Single query: all child email subjects across all threads
+    child_rows = (
+        frappe.qb.from_(SingleEmailCT)
+        .select(SingleEmailCT.parent, SingleEmailCT.subject)
+        .where(SingleEmailCT.subject.isnotnull())
+        .run(as_dict=True)
+    )
+    for row in child_rows:
+        if row.parent in subject_map and row.subject:
+            subject_map[row.parent].add(row.subject.strip())
+
+    updates = {
+        thread_id: {"all_subjects": "\n".join(sorted(subjects))}
+        for thread_id, subjects in subject_map.items()
+    }
+    if not updates:
+        print("[backfill_all_subjects] Nothing to update. Exiting.")
+        return
+
+    frappe.db.bulk_update(
+        "Gmail Thread",
+        updates,
+        chunk_size=100,
+        update_modified=False,
+    )
+
+    frappe.logger().info(f"backfill_all_subjects: updated {len(updates)} threads.")


### PR DESCRIPTION


## Description
This pull request adds an `all_subjects` field to the `Gmail Thread` doctype, which aggregates all unique subjects from a thread's emails and the first mail subject. This enables improved filtering and searching across all subjects in a thread from the list view. The PR also includes logic to populate this field both for new and existing records.

**Enhancement to subject aggregation and searchability:**

* Added a new hidden, read-only `all_subjects` field of type `Small Text` to the `Gmail Thread` doctype schema, and included it in the list view columns for improved filtering/searching. [[1]](diffhunk://#diff-f9d48eb22fe3cb283ee4cb09af546ad391064c69a6c32593a900d1f7b88c4e27L20-R21) [[2]](diffhunk://#diff-f9d48eb22fe3cb283ee4cb09af546ad391064c69a6c32593a900d1f7b88c4e27R99-R106)
* Updated the `before_save` method in `gmail_thread.py` to automatically populate `all_subjects` with a newline-separated, deduplicated list of subjects from the thread's first mail and all associated child emails.

**Data migration for existing records:**

* Introduced a patch script `backfill_all_subjects.py` that efficiently backfills the `all_subjects` field for all existing `Gmail Thread` records by collecting and storing all relevant subjects.
<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
<img width="701" height="205" alt="image" src="https://github.com/user-attachments/assets/e3704fee-e68a-41c5-a2a9-1aedff2a7c17" />

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #https://github.com/rtCamp/frappe-gmail-thread/issues/60